### PR TITLE
Clean up wording in Groupings items

### DIFF
--- a/v1.0.2.html
+++ b/v1.0.2.html
@@ -555,8 +555,8 @@
 (General)
 * You and 1 male
 * You and 1 female
-* You and MtF trans
-* You and FtM trans
+* You and 1 trans female
+* You and 1 trans male
 * You and 1 male, 1 female
 * You and 2 males
 * You and 2 females


### PR DESCRIPTION
MtF and FtM are considered archaic and/or offensive terms by many trans
people. "Trans" is also not a noun. Replace "MtF trans" and "FtM trans"
with "trans female" and "trans male", respectively.

Also prefix trans items with "1" for consistency. (i.e., "1 female",
ergo "1 trans female")